### PR TITLE
minor bugfix

### DIFF
--- a/sample/client/EDAMTest.rb
+++ b/sample/client/EDAMTest.rb
@@ -15,6 +15,7 @@ require "digest/md5"
 # directory of the Evernote API SDK.
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.push("#{dir}/../../lib")
+$LOAD_PATH.push("#{dir}/../../lib/thrift")
 $LOAD_PATH.push("#{dir}/../../lib/Evernote/EDAM")
 
 require "thrift/types"


### PR DESCRIPTION
launching the script "EDAMTest.rb" produced the following message "Unable to load thrift_native extension. Defaulting to pure Ruby libraries."
