### PR TITLE
Handle nil content type in http resp validation.

### DIFF
--- a/evernote-thrift.gemspec
+++ b/evernote-thrift.gemspec
@@ -6,7 +6,7 @@ require 'evernote-thrift'
 
 majorv = Evernote::EDAM::UserStore::EDAM_VERSION_MAJOR
 minorv = Evernote::EDAM::UserStore::EDAM_VERSION_MINOR
-rev = 1
+rev = 2
 version = Gem::Version.new("#{majorv}.#{minorv}.#{rev}").version
 
 Gem::Specification.new do |s|

--- a/lib/thrift/transport/http_client_transport.rb
+++ b/lib/thrift/transport/http_client_transport.rb
@@ -56,8 +56,8 @@ module Thrift
       apply_ssl_attributes(http) if @url.scheme == "https"
 
       resp = http.post(@url.request_uri, @outbuf, @headers)
-      if 'application/x-thrift'.downcase != resp.content_type.downcase
-        raise TransportException.new(TransportException::UNKNOWN, "Unexpected response content type: " + resp.content_type)
+      if 'application/x-thrift'.downcase != resp.content_type.to_s.downcase
+        raise TransportException.new(TransportException::UNKNOWN, "Unexpected response content type: '#{resp.content_type}'")
       end
       data = resp.body
       data = Bytes.force_binary_encoding(data)


### PR DESCRIPTION
This would now raise a more useful `Thrift::HTTPClientTransport Unexpected response content type: ''` error instead of `NoMethodError: undefined method downcase' for nil:NilClass`, mentioned in #17.
