### PR TITLE
avoid warning instance variable @xxx not initialized

### DIFF
--- a/evernote-thrift.gemspec
+++ b/evernote-thrift.gemspec
@@ -6,7 +6,7 @@ require 'evernote-thrift'
 
 majorv = Evernote::EDAM::UserStore::EDAM_VERSION_MAJOR
 minorv = Evernote::EDAM::UserStore::EDAM_VERSION_MINOR
-rev = 2
+rev = 3
 version = Gem::Version.new("#{majorv}.#{minorv}.#{rev}").version
 
 Gem::Specification.new do |s|

--- a/lib/Evernote/EDAM/types_types.rb
+++ b/lib/Evernote/EDAM/types_types.rb
@@ -2097,10 +2097,10 @@ module Evernote
         def struct_fields; FIELDS; end
 
         def validate
-          unless @updateWhichSharedNotebookRestrictions.nil? || ::Evernote::EDAM::Type::SharedNotebookInstanceRestrictions::VALID_VALUES.include?(@updateWhichSharedNotebookRestrictions)
+          if instance_variable_defined?(:@updateWhichSharedNotebookRestrictions) and not ::Evernote::EDAM::Type::SharedNotebookInstanceRestrictions::VALID_VALUES.include?(@updateWhichSharedNotebookRestrictions)
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Invalid value of field updateWhichSharedNotebookRestrictions!')
           end
-          unless @expungeWhichSharedNotebookRestrictions.nil? || ::Evernote::EDAM::Type::SharedNotebookInstanceRestrictions::VALID_VALUES.include?(@expungeWhichSharedNotebookRestrictions)
+          if instance_variable_defined?(:@expungeWhichSharedNotebookRestrictions) and not ::Evernote::EDAM::Type::SharedNotebookInstanceRestrictions::VALID_VALUES.include?(@expungeWhichSharedNotebookRestrictions)
             raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Invalid value of field expungeWhichSharedNotebookRestrictions!')
           end
         end

--- a/lib/thrift/struct.rb
+++ b/lib/thrift/struct.rb
@@ -55,8 +55,7 @@ module Thrift
     end
 
     def fields_with_default_values
-      fields_with_default_values = self.class.instance_variable_get(:@fields_with_default_values)
-      unless fields_with_default_values
+      unless self.class.instance_variable_defined?(:@fields_with_default_values)
         fields_with_default_values = {}
         struct_fields.each do |fid, field_def|
           unless field_def[:default].nil?
@@ -65,7 +64,7 @@ module Thrift
         end
         self.class.instance_variable_set(:@fields_with_default_values, fields_with_default_values)
       end
-      fields_with_default_values
+      self.class.instance_variable_get(:@fields_with_default_values)
     end
     
     def inspect(skip_optional_nulls = true)

--- a/lib/thrift/struct_union.rb
+++ b/lib/thrift/struct_union.rb
@@ -33,12 +33,11 @@ module Thrift
     end
 
     def sorted_field_ids
-      sorted_field_ids = self.class.instance_variable_get(:@sorted_field_ids)
-      unless sorted_field_ids
+      unless self.class.instance_variable_defined?(:@sorted_field_ids)
         sorted_field_ids = struct_fields.keys.sort
         self.class.instance_variable_set(:@sorted_field_ids, sorted_field_ids)
       end
-      sorted_field_ids
+      self.class.instance_variable_get(:@sorted_field_ids)
     end
 
     def each_field


### PR DESCRIPTION
when I `rake test` a gem wrapping evernote-sdk-ruby, it generates hundreds of warning as below

```
gems/evernote-thrift-1.25.2/lib/Evernote/EDAM/types_types.rb:2103: warning: instance variable @expungeWhichSharedNotebookRestrictions not initialized
gems/evernote-thrift-1.25.2/lib/thrift/struct.rb:58: warning: instance variable @fields_with_default_values not initialized
gems/evernote-thrift-1.25.2/lib/thrift/struct_union.rb:36: warning: instance variable @sorted_field_ids not initialized
```

just want to keep console clean, though it is not vital.